### PR TITLE
Remove join action from read-only permissions

### DIFF
--- a/Policies/Azure/Spot-Azure-Connect-Accounts-ReadOnly.json
+++ b/Policies/Azure/Spot-Azure-Connect-Accounts-ReadOnly.json
@@ -30,7 +30,6 @@
       "Microsoft.Network/networkInterfaces/read",
       "Microsoft.Network/networkInterfaces/ipconfigurations/read",
       "Microsoft.Network/networkSecurityGroups/read",
-      "Microsoft.Network/networkSecurityGroups/join/action",
       "Microsoft.Network/publicIPAddresses/read",
       "Microsoft.Network/virtualNetworks/read",
       "Microsoft.Network/virtualNetworks/subnets/read",

--- a/Policies/Azure/Spot-Azure-ReadOnly.json
+++ b/Policies/Azure/Spot-Azure-ReadOnly.json
@@ -29,7 +29,6 @@
         "Microsoft.Network/networkInterfaces/read",
         "Microsoft.Network/networkInterfaces/ipconfigurations/read",
         "Microsoft.Network/networkSecurityGroups/read",
-        "Microsoft.Network/networkSecurityGroups/join/action",
         "Microsoft.Network/publicIPAddresses/read",
         "Microsoft.Network/virtualNetworks/read",
         "Microsoft.Network/virtualNetworks/subnets/read",


### PR DESCRIPTION
According to the [Azure Docs](https://learn.microsoft.com/en-us/azure/virtual-network/manage-network-security-group?tabs=network-security-group-portal#network-security-group), the "Microsoft.Network/networkSecurityGroups/join/action" permission is used to "Associate a network security group to a subnet or network interface", which is not necessary for read-only analysis

