### PR TITLE
(Azure CLI Onboarding Tool) Add support for using an existing App Registration 

### DIFF
--- a/Utilities/AzureOnboardingCLI/azure-automatic-role-assignment.py
+++ b/Utilities/AzureOnboardingCLI/azure-automatic-role-assignment.py
@@ -21,7 +21,15 @@ HTTP_OK_RESPONSE_STATUSES = range(200, 300)
 
 
 def get_subscription_name(subscription_id):
-    """Get the display name of the specified Azure subscription."""
+    """
+    Retrieves the display name of a subscription based on the given subscription ID.
+
+    Parameters:
+        subscription_id (str): The ID of the subscription.
+
+    Returns:
+        str: The display name of the subscription.
+    """
     credential = DefaultAzureCredential()
     subscription_client = SubscriptionClient(credential)
     subscription = subscription_client.subscriptions.get(subscription_id)
@@ -29,7 +37,16 @@ def get_subscription_name(subscription_id):
 
 
 def create_spot_account(name, token):
-    """Create a new Spot Account using the provided token and name"""
+    """
+    Creates a spot account with the given name and token.
+
+    :param name: The name of the spot account.
+    :type name: str
+    :param token: The authentication token.
+    :type token: str
+    :return: The ID of the created spot account.
+    :rtype: str
+    """
     session = SpotinstSession(auth_token=token)
     client = session.client("admin")
     account_result = client.create_account(name)
@@ -37,6 +54,23 @@ def create_spot_account(name, token):
 
 
 def run_command(cmd, *args):
+    """
+    Runs a command with the given arguments and returns the result.
+
+    Args:
+        cmd (str): The command to run.
+        args (tuple): Additional arguments to pass to the command.
+
+    Returns:
+        dict: The result of the command, parsed as a JSON object.
+
+    Raises:
+        Exception: If the command fails to run, an exception is raised with the command and error message.
+
+    Example:
+        >>> run_command("ls", "-l")
+        {'file1.txt': 'rw-r--r--', 'file2.txt': 'rw-rw-r--'}
+    """
     print("Run command: {}".format(cmd))
 
     cmd_args = cmd.split()
@@ -73,6 +107,16 @@ def run_command(cmd, *args):
 
 
 def display_result(subscription, create_or_get_service_principal_response):
+    """
+    Display the result of the subscription and create/get service principal response.
+
+    Args:
+        subscription (str): The subscription ID.
+        create_or_get_service_principal_response (dict): The response from the create or get service principal API.
+
+    Returns:
+        None
+    """
     print("Your credentials details:")
     print("Client Id: {}".format(create_or_get_service_principal_response["appId"]))
     print(
@@ -113,6 +157,22 @@ def set_azure_credentials(
 
 # todo nir - from where take the file in case of using --path param
 def build_custom_role(custom_role_name, custom_role_json_local_path, subscription):
+    """
+    Builds a custom role using the provided custom role name, custom role JSON local path, and subscription.
+
+    Args:
+        custom_role_name (str): The name of the custom role.
+        custom_role_json_local_path (str): The local path to the custom role JSON file. If None, the custom role will be retrieved from S3.
+        subscription (str): The subscription ID.
+
+    Returns:
+        str: The built custom role as a string.
+
+    Raises:
+        FileNotFoundError: If the custom role JSON file is not found at the specified local path.
+        requests.exceptions.RequestException: If there is an error retrieving the custom role from S3.
+
+    """
     if custom_role_json_local_path is not None:
         with open(custom_role_json_local_path) as json_file:
             result = (
@@ -156,6 +216,15 @@ def create_required_parameters_for_spot_registrations(
 
 
 def does_subscription_exist_for_account(subscription):
+    """
+    Check if a subscription exists for an account.
+
+    Args:
+        subscription (str): The ID of the subscription to check.
+
+    Returns:
+        bool: True if the subscription exists for the account, False otherwise.
+    """
     get_account_cmd = "az account list --output json --all"
     accounts = list(run_command(get_account_cmd))
     account_property_with_subscription = next(
@@ -174,6 +243,17 @@ def does_subscription_exist_for_account(subscription):
 
 
 def create_service_principal(custom_role_name, service_principal_name, subscription):
+    """
+    Creates a service principal with the given custom role name, service principal name, and subscription.
+
+    Args:
+        custom_role_name (str): The name of the custom role.
+        service_principal_name (str): The name of the service principal.
+        subscription (str): The subscription ID.
+
+    Returns:
+        str: The result of creating the service principal.
+    """
     print("Create service principal")
     create_service_principal_cmd = "az ad sp create-for-rbac --name {} --role {} --scopes /subscriptions/{}".format(
         service_principal_name, custom_role_name, subscription
@@ -186,6 +266,20 @@ def create_service_principal(custom_role_name, service_principal_name, subscript
 
 
 def create_custom_role(custom_role_name, custom_role_json_local_path, subscription):
+    """
+    Creates a custom role with the given parameters.
+
+    Args:
+        custom_role_name (str): The name of the custom role.
+        custom_role_json_local_path (str): The local path to the custom role JSON file.
+        subscription (str): The subscription to create the custom role in.
+
+    Returns:
+        str: The name of the created custom role.
+
+    Raises:
+        KeyError: If the 'roleName' key is not present in the response from the 'create_custom_role_cmd' command.
+    """
     print("Create custom role")
     custom_role = build_custom_role(
         custom_role_name, custom_role_json_local_path, subscription
@@ -202,12 +296,30 @@ def create_custom_role(custom_role_name, custom_role_json_local_path, subscripti
 
 
 def login_to_azure():
+    """
+    Logs in to Azure by executing the `az login` command.
+
+    This function opens a web page prompting the user to login to their Azure account. Once the user
+    is authenticated, the function executes the `az login` command to complete the login process.
+
+    Parameters:
+    None
+
+    Returns:
+    None
+    """
     print("Please login to azure (Web page should be opened)")
     azure_login_cmd = "az login"
     run_command(azure_login_cmd)
 
 
 def check_azure_cli_installed():
+    """
+    Checks if the Azure CLI is installed by running the 'az' command.
+
+    :return: None
+    :raises Exception: If the 'az' command is not found
+    """
     az_cmd = "az"
     exit_code = subprocess.call(
         az_cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL


### PR DESCRIPTION
Use the --appRegistrationId flag and provide an ID of an existing App Registration in the form of xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx